### PR TITLE
clone is not a function, but a keyword, and so do not need calling paren...

### DIFF
--- a/src/mapper/filter_rule.php
+++ b/src/mapper/filter_rule.php
@@ -100,7 +100,7 @@ class ezcLogFilterRule
      */
     public function __construct( ezcLogFilter $filter, $container, $continueProcessing )
     {
-        $this->filter = clone( $filter );
+        $this->filter = clone $filter;
 
         if ( $this->filter->severity  == 0 )
         {


### PR DESCRIPTION
...thesis